### PR TITLE
MHQA Files Added: main.py, tools.py, README.md

### DIFF
--- a/agent_systems/MHQA/README.md
+++ b/agent_systems/MHQA/README.md
@@ -1,0 +1,31 @@
+## MHQA Agent (Canonical)
+
+This directory contains the canonical, model-agnostic MHQA agent implementation.
+
+- Standardized tool and task vectors with validation
+- Deterministic pipeline (bm25 → dense → merge → reader)
+- Clean `ToolRegistry` for plug-and-play tools
+- Minimal dependencies, suitable for dataset generation and analysis
+
+Usage
+```bash
+python -m agent_systems.MHQA_agent.main \
+  --question "Who wrote The Hobbit?" \
+  --traj_out data/raw/mhqa_demo.traj.json \
+  --vectors_out data/generated_results/tool_task_vectors.json
+```
+
+Tools
+- `BM25Search`, `DenseSearch`, `HybridMerge`, `HeuristicReader`
+
+Artifacts
+- Trajectory: saved to `--traj_out`
+- Vectors: `{ task_vector, tool_vectors }` saved to `--vectors_out`
+
+Note
+
+```bash
+python -m agent_systems.MHQA_agent.main --question "..."
+```
+
+

--- a/agent_systems/MHQA/main.py
+++ b/agent_systems/MHQA/main.py
@@ -1,0 +1,177 @@
+import argparse, json, os, uuid, datetime
+from xml.sax import saxutils as _xml_saxutils
+from typing import Dict, Any, Optional
+
+# The tool layer is deliberately small and model-agnostic.
+from .tools import (
+    register_default_tools,
+    tool_to_vector,
+    validate_tool_vector,
+    text_hash_vector,
+    ToolResult,
+)
+
+
+#
+# Runner for a minimal MHQA-style agent episode.
+#
+# Responsibilities:
+# - Build tool registry and standardized tool vectors
+# - Validate tool vectors to guarantee downstream integrity
+# - Produce a simple task vector
+# - Execute a deterministic pipeline: bm25 -> dense -> merge -> reader
+# - Record a standardized trajectory file plus sidecar vectors
+#
+
+
+def now_iso() -> str:
+    """UTC ISO8601 with trailing Z, without microseconds."""
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def new_step(
+    turn_id: int,
+    phase: str,
+    thought: str,
+    action_block: Optional[str] = None,
+    observation: Dict[str, Any] = None,
+):
+    """Create a two-message step: assistant thought + tool observation.
+
+    Observations are rendered as a simple XML snippet to match existing
+    trajectory tooling in this repository.
+    """
+    content = thought
+    if action_block:
+        content += f"\n\n```bash\n{action_block}\n```"
+    obs_xml = ""
+    if observation:
+        rc = observation.get("returncode")
+        out = observation.get("stdout", "")
+        # Escape XML special characters to ensure well-formed content
+        safe_out = _xml_saxutils.escape(str(out), {"\"": "&quot;", "'": "&apos;"})
+        obs_xml = f"<returncode>{rc}</returncode><output>{safe_out}</output>"
+    return [
+        {"role": "assistant", "content": content, "phase": phase, "turn_id": turn_id},
+        {"role": "tool", "content": obs_xml, "turn_id": turn_id},
+    ]
+
+
+def run_episode(question: str, out_path: str, vectors_path: str):
+    # 1) Tools + vectors
+    reg = register_default_tools()
+    tool_vectors = [tool_to_vector(s) for s in reg.specs()]
+    val_errors = {tv["tool_id"]: validate_tool_vector(tv) for tv in tool_vectors}
+    if any(val_errors[k] for k in val_errors):
+        # Fail early so bad vectors never reach the dataset layer.
+        raise ValueError(f"Invalid tool vectors: {json.dumps(val_errors, indent=2)}")
+
+    # 2) Task vector (deterministic, model-free)
+    task_vec = {
+        "task_id": question[:64],
+        "dim": 128,
+        "vector": text_hash_vector(question, 128),
+        "metadata": {"domain": "mhqa", "tags": []},
+    }
+
+    # 3) Initialize run record
+    run = {
+        "run_id": str(uuid.uuid4()),
+        "domain": "mhqa",
+        "task_id": task_vec["task_id"],
+        "env": "local",
+        "model_name": "none (stub)",
+        "start_time": now_iso(),
+        "end_time": None,
+        "success": False,
+        "stop_reason": "unknown",
+        "steps": [],
+        "used_tools": [],
+        "vectors": {"task_vector": task_vec, "tool_vectors": tool_vectors},
+    }
+
+    # 4) PLAN
+    turn = 1
+    run["steps"] += new_step(turn, "PLAN", f"PLAN: retrieve, merge, read for: '{question}'.")
+
+    # 5) EXEC pipeline
+    turn += 1
+    bm25 = reg.get("bm25_search")(question, k=5)
+    run["used_tools"].append("bm25_search")
+    run["steps"] += new_step(
+        turn,
+        "EXEC",
+        "EXEC: call bm25_search.",
+        "bm25_search(q,k=5)",
+        {"returncode": bm25.returncode, "stdout": bm25.stdout},
+    )
+
+    turn += 1
+    dense = reg.get("dense_search")(question, k=5)
+    run["used_tools"].append("dense_search")
+    run["steps"] += new_step(
+        turn,
+        "EXEC",
+        "EXEC: call dense_search.",
+        "dense_search(q,k=5)",
+        {"returncode": dense.returncode, "stdout": dense.stdout},
+    )
+
+    turn += 1
+    merged = reg.get("hybrid_merge")(bm25.stdout, dense.stdout, k=10)
+    run["used_tools"].append("hybrid_merge")
+    run["steps"] += new_step(
+        turn,
+        "EXEC",
+        "EXEC: merge retrieval results.",
+        "hybrid_merge(bm25,dense,k=10)",
+        {"returncode": merged.returncode, "stdout": merged.stdout},
+    )
+
+    turn += 1
+    read = reg.get("heuristic_reader")(question, merged.stdout)
+    run["used_tools"].append("heuristic_reader")
+    run["steps"] += new_step(
+        turn,
+        "EXEC",
+        "EXEC: extract answer span.",
+        "heuristic_reader(q,merged)",
+        {"returncode": read.returncode, "stdout": read.stdout},
+    )
+
+    # 6) FINALIZE
+    turn += 1
+    run["steps"] += new_step(
+        turn,
+        "FINALIZE",
+        "FINALIZE: return answer.",
+        "echo SUBMIT_FINAL",
+        {"returncode": 0, "stdout": read.stdout},
+    )
+
+    run["end_time"] = now_iso()
+    run["success"] = read.returncode == 0
+    run["stop_reason"] = "solved" if run["success"] else "error"
+
+    # 7) Persist artifacts
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(run, f, ensure_ascii=False, indent=2)
+
+    os.makedirs(os.path.dirname(vectors_path), exist_ok=True)
+    with open(vectors_path, "w", encoding="utf-8") as f:
+        json.dump({"task_vector": task_vec, "tool_vectors": tool_vectors}, f, ensure_ascii=False, indent=2)
+
+    print(f"[ok] saved trajectory to {out_path}")
+    print(f"[ok] saved vectors to {vectors_path}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--question", required=True)
+    ap.add_argument("--traj_out", default="data/raw/episode.traj.json")
+    ap.add_argument("--vectors_out", default="data/generated_results/tool_task_vectors.json")
+    args = ap.parse_args()
+    run_episode(args.question, args.traj_out, args.vectors_out)
+
+

--- a/agent_systems/MHQA/tools.py
+++ b/agent_systems/MHQA/tools.py
@@ -1,0 +1,295 @@
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, List, Callable
+import time, os, json, hashlib, math, urllib.parse, urllib.request
+
+
+#
+# Minimal, model-agnostic tool layer for an MHQA-style agent.
+#
+# Goals:
+# - Provide a tiny set of pluggable tools (BM25, Dense, Merge, Reader)
+# - Standardize tool specifications and their vector representations
+# - Validate tool vectors so downstream pipelines can trust them
+# - Keep logic deterministic and dependency-light (no ML models here)
+#
+
+
+@dataclass
+class ToolResult:
+    """Standard return type for all tools.
+
+    - name: tool identifier (matches spec["id"])  
+    - args: echo of the input args used to invoke the tool  
+    - stdout: primary payload as JSON string for easy piping across steps  
+    - stderr: error message, if any  
+    - returncode: 0 success, non-zero indicates error  
+    - latency_ms: simple wall clock timing to aid analysis
+    """
+    name: str
+    args: Dict[str, Any]
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int = 0
+    latency_ms: Optional[int] = None
+
+
+class ToolRegistry:
+    """Lightweight registry that keeps both specs and callables.
+
+    We keep specs alongside implementations to ensure that any exported
+    vectors or metadata can be traced back to a stable, versioned spec.
+    """
+
+    def __init__(self):
+        self._tools: Dict[str, Callable[..., ToolResult]] = {}
+        self._specs: Dict[str, Dict[str, Any]] = {}
+
+    def register(self, spec: Dict[str, Any], impl: Callable[..., ToolResult]):
+        self._tools[spec["id"]] = impl
+        self._specs[spec["id"]] = spec
+
+    def get(self, tool_id: str) -> Callable[..., ToolResult]:
+        return self._tools[tool_id]
+
+    def specs(self) -> List[Dict[str, Any]]:
+        return list(self._specs.values())
+
+
+def _http_get_json(url: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Tiny helper for best-effort HTTP GET returning parsed JSON.
+
+    We deliberately avoid adding heavy HTTP deps; stdlib is enough here.
+    """
+    qs = urllib.parse.urlencode(params)
+    with urllib.request.urlopen(f"{url}?{qs}", timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+# ------------------------ Domain Tools ------------------------ #
+
+
+class BM25Search:
+    """Optional HTTP client to a BM25 retrieval service.
+
+    If `BM25_API_URL` is unset, we return a minimal stub so trajectories
+    still have realistic shapes for debugging/analysis.
+    """
+
+    spec = {
+        "id": "bm25_search",
+        "name": "BM25 Search",
+        "version": "1.0",
+        "inputs": {"q": "str", "k": "int"},
+        "outputs": {"docs": "List[Dict]"},
+        "description": "HTTP client to BM25 service; falls back to stub.",
+    }
+
+    def __init__(self):
+        self.url = os.getenv("BM25_API_URL")
+
+    def __call__(self, q: str, k: int = 5) -> ToolResult:
+        t0 = time.time()
+        try:
+            if not self.url:
+                docs = [{"title": "Stub BM25", "text": f"fallback for: {q}"}]
+            else:
+                docs = _http_get_json(self.url, {"q": q, "k": k}).get("docs", [])
+            return ToolResult(
+                "bm25_search",
+                {"q": q, "k": k},
+                json.dumps({"docs": docs}),
+                latency_ms=int((time.time() - t0) * 1000),
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            return ToolResult("bm25_search", {"q": q, "k": k}, "", str(e), 2)
+
+
+class DenseSearch:
+    """Optional HTTP client to a dense retrieval service (e.g., BGE/Contriever)."""
+
+    spec = {
+        "id": "dense_search",
+        "name": "Dense Search",
+        "version": "1.0",
+        "inputs": {"q": "str", "k": "int"},
+        "outputs": {"docs": "List[Dict]"},
+        "description": "HTTP client to dense retriever; falls back to stub.",
+    }
+
+    def __init__(self):
+        self.url = os.getenv("DENSE_API_URL")
+
+    def __call__(self, q: str, k: int = 5) -> ToolResult:
+        t0 = time.time()
+        try:
+            if not self.url:
+                docs = [{"title": "Stub Dense", "text": f"fallback for: {q}"}]
+            else:
+                docs = _http_get_json(self.url, {"q": q, "k": k}).get("docs", [])
+            return ToolResult(
+                "dense_search",
+                {"q": q, "k": k},
+                json.dumps({"docs": docs}),
+                latency_ms=int((time.time() - t0) * 1000),
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            return ToolResult("dense_search", {"q": q, "k": k}, "", str(e), 2)
+
+
+class HybridMerge:
+    """Merge BM25 + Dense results with simple title+text dedupe and top-K cut."""
+
+    spec = {
+        "id": "hybrid_merge",
+        "name": "Hybrid Merge",
+        "version": "1.0",
+        "inputs": {"bm25_json": "str", "dense_json": "str", "k": "int"},
+        "outputs": {"docs": "List[Dict]"},
+        "description": "Merge BM25 + Dense with simple dedupe, top-K.",
+    }
+
+    def __call__(self, bm25_json: str, dense_json: str, k: int = 10) -> ToolResult:
+        import hashlib as hh
+        t0 = time.time()
+        try:
+            b = json.loads(bm25_json).get("docs", [])
+            d = json.loads(dense_json).get("docs", [])
+            seen, merged = set(), []
+            for doc in (b + d):
+                key = hh.md5((doc.get("title", "") + "|" + doc.get("text", "")).encode()).hexdigest()
+                if key not in seen:
+                    merged.append(doc)
+                    seen.add(key)
+                if len(merged) >= k:
+                    break
+            return ToolResult(
+                "hybrid_merge",
+                {"k": k},
+                json.dumps({"docs": merged}),
+                latency_ms=int((time.time() - t0) * 1000),
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            return ToolResult("hybrid_merge", {"k": k}, "", str(e), 2)
+
+
+class HeuristicReader:
+    """Very light reader that picks a salient sentence or the first 12 words.
+
+    This is a deterministic, zero-dependency placeholder so that the pipeline
+    exhibits a full trajectory without requiring any ML inference.
+    """
+
+    spec = {
+        "id": "heuristic_reader",
+        "name": "Heuristic Reader",
+        "version": "1.0",
+        "inputs": {"q": "str", "merged_json": "str"},
+        "outputs": {"answer": "str"},
+        "description": "Pick salient sentence or first 12 words from top doc.",
+    }
+
+    def __call__(self, q: str, merged_json: str) -> ToolResult:
+        import re
+        t0 = time.time()
+        try:
+            docs = json.loads(merged_json).get("docs", [])
+            text = " ".join([d.get("text", "") for d in docs[:1]])
+            sents = re.split(r"(?<=[.!?])\s+", text)
+            pick = next(
+                (s.strip() for s in sents if re.search(r"[A-Z][a-z]{2,}", s) or re.search(r"\d", s)),
+                None,
+            )
+            if not pick:
+                pick = " ".join(text.split()[:12]).strip() or "N/A"
+            return ToolResult(
+                "heuristic_reader",
+                {"q": q},
+                json.dumps({"answer": pick}),
+                latency_ms=int((time.time() - t0) * 1000),
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            return ToolResult("heuristic_reader", {"q": q}, "", str(e), 2)
+
+
+# ------------------------ Vectors + Validation ------------------------ #
+
+
+def _hash_float_0_1(s: str) -> float:
+    """Map a string to a deterministic float in [0, 1]."""
+    h = hashlib.md5(s.encode()).hexdigest()
+    return int(h[:8], 16) / 0xFFFFFFFF
+
+
+def text_hash_vector(text: str, dim: int = 128) -> List[float]:
+    """Bag-of-hashed-words vectorizer.
+
+    This is intentionally simple and deterministic. It provides a stable
+    embedding-like vector for tasks and tool specs without requiring models.
+    """
+    tokens = [t for t in text.lower().split() if t]
+    vec = [0.0] * dim
+    for tok in tokens:
+        idx = int(_hash_float_0_1(tok) * dim) % dim
+        vec[idx] += 1.0
+    norm = math.sqrt(sum(x * x for x in vec)) or 1.0
+    return [x / norm for x in vec]
+
+
+def tool_to_vector(spec: Dict[str, Any], dim: int = 128) -> Dict[str, Any]:
+    """Create a deterministic vector for a tool spec.
+
+    We use the tool name/version plus I/O field names and description as the
+    textual seed. A checksum of the spec is included for integrity checks.
+    """
+    desc = (
+        f'{spec["name"]} {spec["version"]} '
+        + " ".join(list(spec.get("inputs", {}).keys()) + list(spec.get("outputs", {}).keys()))
+        + " "
+        + spec.get("description", "")
+    )
+    vec = text_hash_vector(desc, dim)
+    checksum = hashlib.md5(json.dumps(spec, sort_keys=True).encode()).hexdigest()
+    return {
+        "tool_id": spec["id"],
+        "dim": dim,
+        "vector": vec,
+        "metadata": {
+            "name": spec.get("name"),
+            "version": spec.get("version"),
+            "tags": [],
+            "checksum": checksum,
+        },
+    }
+
+
+def validate_tool_vector(tv: Dict[str, Any]) -> List[str]:
+    """Return a list of validation errors (empty list means valid)."""
+    errs: List[str] = []
+    if not isinstance(tv.get("tool_id"), str):
+        errs.append("tool_id must be str")
+    vec = tv.get("vector")
+    if not isinstance(vec, list) or not vec:
+        errs.append("vector must be non-empty list")
+    if isinstance(vec, list) and any((not isinstance(x, (int, float)) or not math.isfinite(x)) for x in vec):
+        errs.append("vector elements must be finite numbers")
+    if tv.get("dim") != (len(vec) if isinstance(vec, list) else None):
+        errs.append("dim must equal len(vector)")
+    # Use a small epsilon to tolerate floating-point noise for near-zero norms
+    if sum((x * x for x in (vec or []))) <= 1e-12:
+        errs.append("vector norm must be > 0")
+    meta = tv.get("metadata", {})
+    if "checksum" not in meta:
+        errs.append("metadata.checksum required")
+    return errs
+
+
+def register_default_tools() -> ToolRegistry:
+    """Factory that returns a registry populated with default tools."""
+    reg = ToolRegistry()
+    reg.register(BM25Search.spec, BM25Search())
+    reg.register(DenseSearch.spec, DenseSearch())
+    reg.register(HybridMerge.spec, HybridMerge())
+    reg.register(HeuristicReader.spec, HeuristicReader())
+    return reg
+
+


### PR DESCRIPTION
## MHQA Agent (Canonical)

This directory contains the canonical, model-agnostic MHQA agent implementation.

- Standardized tool and task vectors with validation
- Deterministic pipeline (bm25 → dense → merge → reader)
- Clean `ToolRegistry` for plug-and-play tools
- Minimal dependencies, suitable for dataset generation and analysis

Usage
```bash
python -m agent_systems.MHQA_agent.main \
  --question "Who drew the Mona Lisa?" \
  --traj_out data/raw/mhqa_demo.traj.json \
  --vectors_out data/generated_results/tool_task_vectors.json
```

Tools
- `BM25Search`, `DenseSearch`, `HybridMerge`, `HeuristicReader`

Artifacts
- Trajectory: saved to `--traj_out`
- Vectors: `{ task_vector, tool_vectors }` saved to `--vectors_out`

Note

```bash
python -m agent_systems.MHQA_agent.main --question "..."
```


